### PR TITLE
feat: test email mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 ## 1.3.0 (2024-08-12)
 
-
 ### 🩹 Fixes
 
-- ignore collection dirs ([d26eb66](https://github.com/icdocsoc/docsoc-tools/commit/d26eb66))
+-   ignore collection dirs ([d26eb66](https://github.com/icdocsoc/docsoc-tools/commit/d26eb66))
+-   Add --only & moving of drafts [396b645](https://github.com/icdocsoc/docsoc-tools/commit/396b645)
 
-### ❤️  Thank You
+### ❤️ Thank You
 
-- Kishan Sambhi @Gum-Joe
+-   Kishan Sambhi @Gum-Joe
 
 ## 1.2.1 (2024-08-06)
 
@@ -15,26 +15,24 @@ This was a version bump only, there were no code changes.
 
 ## 1.2.0 (2024-08-06)
 
-
 ### 🩹 Fixes
 
-- build cli in place so oclif won't complain ([596a78c](https://github.com/icdocsoc/docsoc-tools/commit/596a78c))
-- tests breaking because ESM ([49823c9](https://github.com/icdocsoc/docsoc-tools/commit/49823c9))
+-   build cli in place so oclif won't complain ([596a78c](https://github.com/icdocsoc/docsoc-tools/commit/596a78c))
+-   tests breaking because ESM ([49823c9](https://github.com/icdocsoc/docsoc-tools/commit/49823c9))
 
-### ❤️  Thank You
+### ❤️ Thank You
 
-- Kishan Sambhi @Gum-Joe
+-   Kishan Sambhi @Gum-Joe
 
 ## 1.1.2 (2024-08-06)
 
-
 ### 🩹 Fixes
 
-- add bin to mailmerge cli bundle ([8fec651](https://github.com/icdocsoc/docsoc-tools/commit/8fec651))
+-   add bin to mailmerge cli bundle ([8fec651](https://github.com/icdocsoc/docsoc-tools/commit/8fec651))
 
-### ❤️  Thank You
+### ❤️ Thank You
 
-- Kishan Sambhi @Gum-Joe
+-   Kishan Sambhi @Gum-Joe
 
 ## 1.1.1 (2024-08-06)
 
@@ -46,20 +44,19 @@ This was a version bump only, there were no code changes.
 
 # 1.0.0 (2024-08-06)
 
-
 ### 🚀 Features
 
-- scaffold up full preview renderer ([a41320e](https://github.com/icdocsoc/docsoc-tools/commit/a41320e))
-- rerendering of templates ([ea21d57](https://github.com/icdocsoc/docsoc-tools/commit/ea21d57))
-- init command fix: issue where nunjucks didn't pass it all ([5eb8b75](https://github.com/icdocsoc/docsoc-tools/commit/5eb8b75))
-- **nx:** Added Nx Cloud token to your nx.json ([646eb34](https://github.com/icdocsoc/docsoc-tools/commit/646eb34))
-- **nx:** Generated CI workflow ([abf6ea5](https://github.com/icdocsoc/docsoc-tools/commit/abf6ea5))
+-   scaffold up full preview renderer ([a41320e](https://github.com/icdocsoc/docsoc-tools/commit/a41320e))
+-   rerendering of templates ([ea21d57](https://github.com/icdocsoc/docsoc-tools/commit/ea21d57))
+-   init command fix: issue where nunjucks didn't pass it all ([5eb8b75](https://github.com/icdocsoc/docsoc-tools/commit/5eb8b75))
+-   **nx:** Added Nx Cloud token to your nx.json ([646eb34](https://github.com/icdocsoc/docsoc-tools/commit/646eb34))
+-   **nx:** Generated CI workflow ([abf6ea5](https://github.com/icdocsoc/docsoc-tools/commit/abf6ea5))
 
 ### 🩹 Fixes
 
-- throw error on undefined value ([15c45ab](https://github.com/icdocsoc/docsoc-tools/commit/15c45ab))
-- stop if uploaded ([ea0b979](https://github.com/icdocsoc/docsoc-tools/commit/ea0b979))
+-   throw error on undefined value ([15c45ab](https://github.com/icdocsoc/docsoc-tools/commit/15c45ab))
+-   stop if uploaded ([ea0b979](https://github.com/icdocsoc/docsoc-tools/commit/ea0b979))
 
-### ❤️  Thank You
+### ❤️ Thank You
 
-- Kishan Sambhi @Gum-Joe
+-   Kishan Sambhi @Gum-Joe

--- a/email/mailmerge-cli/src/commands/send.ts
+++ b/email/mailmerge-cli/src/commands/send.ts
@@ -8,7 +8,6 @@ import {
     Mailer,
 } from "@docsoc/mailmerge";
 import { Args, Command, Flags } from "@oclif/core";
-import test from "node:test";
 
 export default class Send extends Command {
     static override args = {

--- a/email/mailmerge/src/pipelines/send.spec.ts
+++ b/email/mailmerge/src/pipelines/send.spec.ts
@@ -123,22 +123,19 @@ describe("sendEmails", () => {
         expect(mockMailer.sendMail).toHaveBeenCalledTimes(1);
     });
 
-    it("should send to test email if given", async () => {
+    it("should send to test email if given and not cc or bcc anyone in", async () => {
         const mergeResults: MergeResultWithMetadata<unknown>[] = [
             {
                 record: { field1: "value1" },
                 /// @ts-expect-error: Mocking previews
                 previews: ["preview"],
                 engineInfo: { name: "testEngine", options: {} },
-                email: { to: ["test@example.com"], subject: "Test Subject", cc: [], bcc: [] },
-                attachmentPaths: [],
-            },
-            {
-                record: { field1: "value2" },
-                /// @ts-expect-error: Mocking previews
-                previews: ["preview"],
-                engineInfo: { name: "testEngine", options: {} },
-                email: { to: ["test@example2.com"], subject: "Test Subject 2", cc: [], bcc: [] },
+                email: {
+                    to: ["test@example.com"],
+                    subject: "Test Subject",
+                    cc: ["cc@cc.com"],
+                    bcc: ["bcc@bcc.com"],
+                },
                 attachmentPaths: [],
             },
         ];
@@ -163,10 +160,13 @@ describe("sendEmails", () => {
         expect(mockMailer.sendMail).toHaveBeenCalledWith(
             '"From" <from@example.com>',
             ["test@example.com"],
-            expect.any(String),
+            "(TEST) Test Subject",
             expect.any(String),
             [],
-            expect.anything(),
+            {
+                cc: [],
+                bcc: [],
+            },
         );
     });
 

--- a/email/workspace/data/names.csv
+++ b/email/workspace/data/names.csv
@@ -1,3 +1,3 @@
 name,to,subject,attachment1,attachment2,bcc,cc
-Kishan,kss22@ic.ac.uk kishansambhi@hotmail.co.uk,DoCSoc x Kishan,./attachments/DoCSoc Sponsorship Proposal 24-25.pdf,./attachments/munch.jpg,kishansambhi@hotmail.co.uk,jaskishansaran@gmail.com kishansambhi@outlook.com
+Kishan,kishansambhi@hotmail.co.uk,DoCSoc x Kishan,./attachments/DoCSoc Sponsorship Proposal 24-25.pdf,./attachments/munch.jpg,kishansambhi@hotmail.co.uk,jaskishansaran@gmail.com kishansambhi@outlook.com
 NotKishan,kishansambhi@hotmail.co.uk," DoCSoc x NotKishan",./attachments/DoCSoc Sponsorship Proposal 24-25.pdf,./attachments/munch.jpg,,

--- a/email/workspace/quick-run.sh
+++ b/email/workspace/quick-run.sh
@@ -1,4 +1,4 @@
 docsoc-mailmerge generate nunjucks ./data/names.csv -o ./output -n test -b -c
 docsoc-mailmerge regenerate ./output/test
-docsoc-mailmerge upload-drafts ./output/test -y -s 2 -n 1
-docsoc-mailmerge send ./output/test -s 5 -n 1
+# docsoc-mailmerge upload-drafts ./output/test -y -s 2 -n 1
+docsoc-mailmerge send ./output/test -s 5 -n 2 -t "kss22@ic.ac.uk"


### PR DESCRIPTION
Add a new test email mode that will send to a test email instead of the real one. Requires --onlySend to be set.